### PR TITLE
[Dev Containers] Support for sourcing env (PATH, LD_LIBRARY_PATH) via `activate` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ WORKDIR ${WORKDIR}
 # Install IREE, ROCm, HIP deps through an entrypoint script
 # to keep the base image small and portable.
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY activate /usr/local/bin/activate
 RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ Simply clone this repo:
 git clone https://github.com/sjain-stanford/docker.git
 ```
 
+### Interactive development
+
 Switch over to the development repo and launch an interactive container:
 ```
 /path/to/docker/run_docker.sh
 ```
 
-This launches an interactive shell within the container. All code in the current directory should be visible (volume mounted) within the container at the same paths, preserving the source structure to keep builds within container in sync with utilities outside (e.g. `compile_commands.json`, C++ Intellisense, gcov-viewer etc.). The container also mounts user's home directory so that their configuration works as-is within the container (e.g. `.bashrc`, `.gitconfig` etc).
+This launches an interactive shell within the container. All code in the current directory should be visible (volume mounted) within the container at the same paths, preserving the source structure to keep builds within container in sync with utilities outside (e.g. `compile_commands.json`, C++ Intellisense, gcov-viewer etc.). The container also mounts user's home directory so that their configuration works as-is within the container (e.g. `.bashrc`, `.gitconfig` etc). The container automatically sources its virtual environment in the interactive shell, which should reflect in `$PATH` and `$LD_LIBRARY_PATH` appropriately. This may be manually disabled with `deactivate` and re-enabled with `source activate`.
 
-To execute commands within the container non-interactively:
+To use VSCode's integrated debugger with the container, we recommend using the "Dev Containers" extension. Simply `run_docker.sh` to launch the container, then press Ctrl+Shift+P (or Cmd+Shift+P on macOS) to open the command palette and select "Dev Containers: Attach to Running Container...". See [this](https://code.visualstudio.com/docs/devcontainers/attach-container) for details.
+
+
+### Non-interactive usage (CI)
+
+To execute commands within the container in batch mode (non-interactive):
 ```
 /path/to/docker/exec_docker.sh <command>
 ```

--- a/activate
+++ b/activate
@@ -13,17 +13,25 @@ deactivate () {
         export PYTHONHOME
         unset _OLD_VIRTUAL_PYTHONHOME
     fi
-
-    # Call hash to forget past commands. Without forgetting
-    # past commands the $PATH changes we made may not be respected
-    hash -r 2> /dev/null
-
+    if [ -n "${_OLD_VIRTUAL_LD_LIBRARY_PATH:-}" ] ; then
+        LD_LIBRARY_PATH="${_OLD_VIRTUAL_LD_LIBRARY_PATH:-}"
+        export LD_LIBRARY_PATH
+        unset _OLD_VIRTUAL_LD_LIBRARY_PATH
+    else
+        unset LD_LIBRARY_PATH
+    fi
     if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
         PS1="${_OLD_VIRTUAL_PS1:-}"
         export PS1
         unset _OLD_VIRTUAL_PS1
     fi
 
+    # Call hash to forget past commands. Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    hash -r 2> /dev/null
+
+    unset DOCKER_CACHE_DIR
+    unset THEROCK_DIR
     unset VIRTUAL_ENV
     unset VIRTUAL_ENV_PROMPT
     if [ ! "${1:-}" = "nondestructive" ] ; then
@@ -35,11 +43,23 @@ deactivate () {
 # unset irrelevant variables
 deactivate nondestructive
 
-export VIRTUAL_ENV=${PWD}/.cache/docker/venv
+export DOCKER_CACHE_DIR=${PWD}/.cache/docker
+export THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
+export VIRTUAL_ENV=${DOCKER_CACHE_DIR}/venv
 
-_OLD_VIRTUAL_PATH="$PATH"
-PATH="$VIRTUAL_ENV/"bin":$PATH"
+# save old PATH and re-export
+_OLD_VIRTUAL_PATH="${PATH}"
+PATH="${VIRTUAL_ENV}/bin:${THEROCK_DIR}/bin:${PATH}"
 export PATH
+
+# save old LD_LIBRARY_PATH and re-export
+if [ -n "${LD_LIBRARY_PATH:-}" ] ; then
+    _OLD_VIRTUAL_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+    LD_LIBRARY_PATH="${THEROCK_DIR}/lib:${LD_LIBRARY_PATH:-}"
+else
+    LD_LIBRARY_PATH="${THEROCK_DIR}/lib"
+fi
+export LD_LIBRARY_PATH
 
 # unset PYTHONHOME if set
 # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)

--- a/activate
+++ b/activate
@@ -1,0 +1,62 @@
+# This file must be used with "source bin/activate" *from bash*
+# You cannot run it directly
+
+deactivate () {
+    # reset old environment variables
+    if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
+        PATH="${_OLD_VIRTUAL_PATH:-}"
+        export PATH
+        unset _OLD_VIRTUAL_PATH
+    fi
+    if [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
+        PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
+        export PYTHONHOME
+        unset _OLD_VIRTUAL_PYTHONHOME
+    fi
+
+    # Call hash to forget past commands. Without forgetting
+    # past commands the $PATH changes we made may not be respected
+    hash -r 2> /dev/null
+
+    if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
+        PS1="${_OLD_VIRTUAL_PS1:-}"
+        export PS1
+        unset _OLD_VIRTUAL_PS1
+    fi
+
+    unset VIRTUAL_ENV
+    unset VIRTUAL_ENV_PROMPT
+    if [ ! "${1:-}" = "nondestructive" ] ; then
+    # Self destruct!
+        unset -f deactivate
+    fi
+}
+
+# unset irrelevant variables
+deactivate nondestructive
+
+export VIRTUAL_ENV=${PWD}/.cache/docker/venv
+
+_OLD_VIRTUAL_PATH="$PATH"
+PATH="$VIRTUAL_ENV/"bin":$PATH"
+export PATH
+
+# unset PYTHONHOME if set
+# this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
+# could use `if (set -u; : $PYTHONHOME) ;` in bash
+if [ -n "${PYTHONHOME:-}" ] ; then
+    _OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
+    unset PYTHONHOME
+fi
+
+if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
+    _OLD_VIRTUAL_PS1="${PS1:-}"
+    PS1='(venv) '"${PS1:-}"
+    export PS1
+    VIRTUAL_ENV_PROMPT='(venv) '
+    export VIRTUAL_ENV_PROMPT
+fi
+
+# Call hash to forget past commands. Without forgetting
+# past commands the $PATH changes we made may not be respected
+hash -r 2> /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,13 +77,12 @@ fi
 
 # Export PATH and LD_LIBRARY_PATH in .bashrc for interactive shells and dev-containers
 BASHRC_FILE="${HOME}/.bashrc"
-if ! grep -qF -- "[Compiler Docker] Setup PATH and LD_LIBRARY_PATH" "${BASHRC_FILE}" 2>/dev/null; then
-    echo "Adding PATH and LD_LIBRARY_PATH exports to ${BASHRC_FILE}"
-    echo -e "\n# [Compiler Docker] Setup PATH and LD_LIBRARY_PATH" >> "${BASHRC_FILE}"
-    # Setting PATH to ${VENV_DIR}/bin is equivalent to activating the venv
-    # https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
-    echo "export PATH=\"${VENV_DIR}/bin:${THEROCK_DIR}/bin:${PATH}\"" >> "${BASHRC_FILE}"
-    echo "export LD_LIBRARY_PATH=\"${THEROCK_DIR}/lib:${LD_LIBRARY_PATH}\"" >> "${BASHRC_FILE}"
+if ! grep -qF -- "[Compiler Docker] Source VENV for PATH and LD_LIBRARY_PATH changes" "${BASHRC_FILE}" 2>/dev/null; then
+    echo "entrypoint.sh: Adding VENV source activate to ${BASHRC_FILE}"
+    echo -e "\n# [Compiler Docker] Source VENV for PATH and LD_LIBRARY_PATH changes" >> "${BASHRC_FILE}"
+    echo "source /usr/local/bin/activate" >> "${BASHRC_FILE}"
+else
+    echo "entrypoint.sh: Found VENV source activate in ${BASHRC_FILE}, skipped editing..."
 fi
 
 # Execute the command passed to the container

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Install dirs
-CACHE_DIR=${PWD}/.cache/docker
-THEROCK_DIR=${CACHE_DIR}/therock
-IREE_DIR=${CACHE_DIR}/iree
-VENV_DIR=${CACHE_DIR}/venv
+DOCKER_CACHE_DIR=${PWD}/.cache/docker
+VENV_DIR=${DOCKER_CACHE_DIR}/venv
+THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
+IREE_DIR=${DOCKER_CACHE_DIR}/iree
 
 # Version pins
 IREE_GIT_TAG=3.8.0rc20250922
@@ -17,12 +17,12 @@ THEROCK_TAR=${THEROCK_DIST}-${THEROCK_GIT_TAG}.tar.gz
 # instantaneous. However, the cache is NOT automatically invalidated and needs
 # to be cleared manually (like when library versions are bumped). To clear the
 # installation cache, simply remove the `${PWD}/.cache/docker` dir and re-run.
-if [ ! -f "${CACHE_DIR}/.install_complete" ]; then
-    echo "entrypoint.sh: Cache NOT found at ${CACHE_DIR}, proceeding with installation..."
-    mkdir -p ${CACHE_DIR}
+if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete" ]; then
+    echo "entrypoint.sh: Cache NOT found at ${DOCKER_CACHE_DIR}, proceeding with installation..."
+    mkdir -p ${DOCKER_CACHE_DIR}
     # Remove partial/corrupt cache contents that may have been
     # populated without a `.install_complete`.
-    rm -rf ${CACHE_DIR}/*
+    rm -rf ${DOCKER_CACHE_DIR}/*
 
     # Install TheRock (ROCm/HIP) for GFX942
     echo "entrypoint.sh: Downloading TheRock (ROCm/HIP) prebuilt distribution for GFX942..."
@@ -69,18 +69,23 @@ if [ ! -f "${CACHE_DIR}/.install_complete" ]; then
         iree-base-compiler==${IREE_GIT_TAG}
 
     # Used to validate cache for future runs
-    touch "${CACHE_DIR}/.install_complete"
+    touch "${DOCKER_CACHE_DIR}/.install_complete"
 
 else
-    echo "entrypoint.sh: Cache found at ${CACHE_DIR}, skipped installation..."
+    echo "entrypoint.sh: Cache found at ${DOCKER_CACHE_DIR}, skipped installation..."
 fi
 
 # Export PATH and LD_LIBRARY_PATH in .bashrc for interactive shells and dev-containers
 BASHRC_FILE="${HOME}/.bashrc"
-if ! grep -qF -- "[Compiler Docker] Source VENV for PATH and LD_LIBRARY_PATH changes" "${BASHRC_FILE}" 2>/dev/null; then
+MARKER="# [Compiler Docker] Source VENV for PATH and LD_LIBRARY_PATH changes"
+if ! grep -qF -- "${MARKER}" "${BASHRC_FILE}" 2>/dev/null; then
     echo "entrypoint.sh: Adding VENV source activate to ${BASHRC_FILE}"
-    echo -e "\n# [Compiler Docker] Source VENV for PATH and LD_LIBRARY_PATH changes" >> "${BASHRC_FILE}"
-    echo "source /usr/local/bin/activate" >> "${BASHRC_FILE}"
+    {
+        echo -e "\n${MARKER}"
+        echo "if [ -f /usr/local/bin/activate ]; then"
+        echo "    source /usr/local/bin/activate"
+        echo "fi"
+    } >> "${BASHRC_FILE}"
 else
     echo "entrypoint.sh: Found VENV source activate in ${BASHRC_FILE}, skipped editing..."
 fi


### PR DESCRIPTION
Adds an `activate` script that manages the user env within the container just like a virtual environment. With this fix we should be able to attach to an existing container without relying on the `entrypoint.sh` to export the relevant env vars (`$PATH`, `$LD_LIBRARY_PATH`). It also lets you `deactivate` to go back to the previous state of your shell.