### PR TITLE
Critical Fixes

### DIFF
--- a/activate
+++ b/activate
@@ -52,6 +52,7 @@ deactivate () {
 # unset irrelevant variables
 deactivate nondestructive
 
+# CAUTION: These directories need to be kept in sync with the `entrypoint.sh` script!!
 export DOCKER_CACHE_DIR=${PWD}/.cache/docker
 export THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
 export VIRTUAL_ENV=${DOCKER_CACHE_DIR}/venv

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Install dirs
+# CAUTION: These directories need to be kept in sync with the `activate` script!!
 DOCKER_CACHE_DIR=${PWD}/.cache/docker
 VENV_DIR=${DOCKER_CACHE_DIR}/venv
 THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
@@ -61,11 +62,12 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete" ]; then
     # Install python virtual env and dependencies
     echo "entrypoint.sh: Setting up python venv and installing pip deps..."
     python3 -m venv ${VENV_DIR}
-    source ${VENV_DIR}/bin/activate
+    source /usr/local/bin/activate
     pip install \
         lit \
         --find-links https://iree.dev/pip-release-links.html \
         iree-base-compiler==${IREE_GIT_TAG}
+    deactivate
 
     # Used to validate cache for future runs
     touch "${DOCKER_CACHE_DIR}/.install_complete"


### PR DESCRIPTION
Don't activate the wrong env for the pip installs - this prevents the correct env from being sourced (because of the duplicate sourcing checks we added to the top of `activate`). Source the correct env and deactivate immediately after.