### PR TITLE
Make clang-20 the default clang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,7 @@ RUN apt-get update && \
     vim \
     wget && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/lib/llvm-18/bin/FileCheck /usr/bin/FileCheck
+    rm -rf /var/lib/apt/lists/*
 
 # Install bazel
 ARG ARCH=x86_64

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -68,6 +68,13 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete" ]; then
         --find-links https://iree.dev/pip-release-links.html \
         iree-base-compiler==${IREE_GIT_TAG}
 
+    # Make FileCheck (from system llvm-18) and clang-20 (from TheRock) accessible in VENV
+    ln -s /usr/lib/llvm-18/bin/FileCheck ${VENV_DIR}/bin/FileCheck
+    ln -s ${THEROCK_DIR}/lib/llvm/bin/clang-20 ${VENV_DIR}/bin/clang-20
+    ln -s ${THEROCK_DIR}/lib/llvm/bin/clang-20 ${VENV_DIR}/bin/clang++-20
+    ln -s ${VENV_DIR}/bin/clang-20 ${VENV_DIR}/bin/clang
+    ln -s ${VENV_DIR}/bin/clang++-20 ${VENV_DIR}/bin/clang++
+
     # Used to validate cache for future runs
     touch "${DOCKER_CACHE_DIR}/.install_complete"
 


### PR DESCRIPTION
`clang`, `clang-20`, `clang++` and `clang++-20` all point to `${THEROCK_DIR}/lib/llvm/bin/clang-20`. 

`clang-18` (from system clang at `/usr/lib/llvm-18/bin/clang`) is still accessible
