### PR TITLE
Cache the cache location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ RUN apt-get update && \
     aria2 \
     bash-completion \
     black \
+    sudo \
     catch2 \
     ccache \
     clang \
     clang-format \
+    cmake-curses-gui \
     cmake \
     gdb \
     git \
@@ -64,6 +66,7 @@ RUN if [ "$UID" != "0" ]; then \
     groupadd -o -g ${GID} ${GROUP} && \
     useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
     usermod -aG sudo ${USER} && \
+    echo "${USER} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER} && \
     chown -R ${USER}:${GROUP} ${WORKDIR}; \
     fi
 

--- a/activate
+++ b/activate
@@ -1,8 +1,12 @@
 # This file must be used with "source bin/activate" *from bash*
 # You cannot run it directly
 
+# Variable passed to bin/activate by install command written into .bashrc during
+# cache creation.
+DOCKER_CACHE_BASE_DIR=${1}
+
 # Check if already activated to avoid double patching
-if [ -n "${VIRTUAL_ENV:-}" ] && [ "${VIRTUAL_ENV}" = "${PWD}/.cache/docker/venv" ]; then
+if [ -n "${VIRTUAL_ENV:-}" ] && [ "${VIRTUAL_ENV}" = "${DOCKER_CACHE_BASE_DIR}/.cache/docker/venv" ]; then
     # Already activated: skip overriding env variables and early return
     # `return 0` tries to return from the script — this only works if the script is being sourced.
     # `2>/dev/null` suppresses errors in case return is invalid (e.g., script is run, not sourced).
@@ -53,7 +57,7 @@ deactivate () {
 deactivate nondestructive
 
 # CAUTION: These directories need to be kept in sync with the `entrypoint.sh` script!!
-export DOCKER_CACHE_DIR=${PWD}/.cache/docker
+export DOCKER_CACHE_DIR=${DOCKER_CACHE_BASE_DIR}/.cache/docker
 export THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
 export VIRTUAL_ENV=${DOCKER_CACHE_DIR}/venv
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,7 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete" ]; then
             -DIREE_HAL_DRIVER_DEFAULTS=OFF \
             -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
             -DIREE_HAL_DRIVER_LOCAL_TASK=ON \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DIREE_HAL_DRIVER_HIP=ON \
             -DHIP_API_HEADERS_ROOT=${THEROCK_DIR}/include
         cmake --build build --target all
@@ -93,7 +94,8 @@ if [ -t 0 ]; then
         {
             echo -e "\n${MARKER}"
             echo "if [ -f /usr/local/bin/activate ]; then"
-            echo "    source /usr/local/bin/activate"
+            echo "    DOCKER_CACHE_BASE_DIR=\"${PWD}\""
+            echo "    source /usr/local/bin/activate \${DOCKER_CACHE_BASE_DIR}"
             echo "fi"
         } >> "${BASHRC_FILE}"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,6 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete" ]; then
             -DIREE_HAL_DRIVER_DEFAULTS=OFF \
             -DIREE_HAL_DRIVER_LOCAL_SYNC=ON \
             -DIREE_HAL_DRIVER_LOCAL_TASK=ON \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DIREE_HAL_DRIVER_HIP=ON \
             -DHIP_API_HEADERS_ROOT=${THEROCK_DIR}/include
         cmake --build build --target all


### PR DESCRIPTION
When starting new terminals *not* from the directory the cache is in, `$PATH` update logic is incorrect. This PR ensures that cache location is passed to the activate script, ensuring that the logic works for terminals launched at different `$PWD`s