### PR TITLE
Mount ~/.cursor into dev container for Cursor config access

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -81,7 +81,7 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete_${CACHE_KEY}" ]; then
         --find-links https://iree.dev/pip-release-links.html \
         iree-base-compiler==${IREE_GIT_TAG}
 
-    # Make FileCheck (from system llvm-18) and clang-22, llvm-symbolizer (from TheRock) accessible in VENV
+    # Make FileCheck (from system llvm-18) and clang-23, llvm-symbolizer (from TheRock) accessible in VENV
     ln -s /usr/lib/llvm-18/bin/FileCheck ${VENV_DIR}/bin/FileCheck
     # TODO(sjain-stanford): clang-tidy from TheRock segfaults. Use system clang-tidy instead.
     # ln -s ${THEROCK_DIR}/lib/llvm/bin/clang-tidy ${VENV_DIR}/bin/clang-tidy

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -9,6 +9,7 @@ DOCKER_RUN_MOUNT_OPTS+=" -v ${PWD}:${PWD}"
 [ -e "${HOME}/.claude.json" ]        && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.claude.json:${HOME}/.claude.json"
 [ -e "${HOME}/.local/state/claude" ] && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.local/state/claude:${HOME}/.local/state/claude"
 [ -e "${HOME}/.cache" ]              && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cache:${HOME}/.cache"
+[ -e "${HOME}/.cursor" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cursor:${HOME}/.cursor"
 [ -e "${HOME}/.cursor-server" ]      && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cursor-server:${HOME}/.cursor-server"
 # Read-only mounts
 [ -e "${HOME}/.ssh" ]                && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.ssh:${HOME}/.ssh:ro"


### PR DESCRIPTION
## Summary

- Mount `~/.cursor` so Cursor IDE settings and MCP configs are accessible inside the dev container.
- Fix stale comment referencing clang-22 → clang-23 in entrypoint.sh.

Made with [Cursor](https://cursor.com)