### PR TITLE
Fix dev-container home ownership and bashrc mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN if [ "$UID" != "0" ]; then \
     useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
     usermod -aG sudo ${USER} && \
     echo "${USER} ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg, /usr/bin/tee, /usr/bin/chown, /usr/bin/chmod" > /etc/sudoers.d/${USER} && \
-    chown -R ${USER}:${GROUP} ${WORKDIR}; \
+    chown -R ${USER}:${GROUP} /home/${USER} ${WORKDIR}; \
     fi
 
 # Strip setuid/setgid bits — none are needed inside a dev container

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN if [ "$UID" != "0" ]; then \
     useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
     usermod -aG sudo ${USER} && \
     echo "${USER} ALL=(ALL) NOPASSWD: /usr/bin/apt-get, /usr/bin/apt, /usr/bin/dpkg, /usr/bin/tee, /usr/bin/chown, /usr/bin/chmod" > /etc/sudoers.d/${USER} && \
-    chown -R ${USER}:${GROUP} /home/${USER} ${WORKDIR}; \
+    chown -R ${USER}:${GROUP} ${WORKDIR} /home/${USER}; \
     fi
 
 # Strip setuid/setgid bits — none are needed inside a dev container

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,11 @@ CMD ["/bin/bash"]
 # Mirror user and group within container and set ownerships
 # only if building as non-root user (i.e., GROUP, GID, USER,
 # UID and WORKDIR are specified args to docker build)
+#
+# NOTE: When WORKDIR lies under /home/${USER} the WORKDIR instruction above
+# already created the home as root -- useradd -m skips chown on a pre-existing
+# home. We chown /home/${USER} as well as ${WORKDIR} to ensure that the user
+# owns /home/${USER}.
 RUN if [ "$UID" != "0" ]; then \
     groupadd -o -g ${GID} ${GROUP} && \
     useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -11,13 +11,15 @@ DOCKER_RUN_MOUNT_OPTS+=" -v ${PWD}:${PWD}"
 [ -e "${HOME}/.cache" ]              && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cache:${HOME}/.cache"
 [ -e "${HOME}/.cursor" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cursor:${HOME}/.cursor"
 [ -e "${HOME}/.cursor-server" ]      && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.cursor-server:${HOME}/.cursor-server"
+# .bashrc is mounted read-write so `entrypoint.sh` can append its
+# VENV-activation stanza (see entrypoint.sh).
+[ -e "${HOME}/.bashrc" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bashrc:${HOME}/.bashrc"
 # Read-only mounts
 [ -e "${HOME}/.ssh" ]                && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.ssh:${HOME}/.ssh:ro"
 [ -e "${HOME}/.gitconfig" ]          && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.gitconfig:${HOME}/.gitconfig:ro"
 [ -e "${HOME}/.config" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.config:${HOME}/.config:ro"
 [ -e "${HOME}/.gnupg" ]              && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.gnupg:${HOME}/.gnupg:ro"
 [ -e "${HOME}/.local" ]              && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.local:${HOME}/.local:ro"
-[ -e "${HOME}/.bashrc" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bashrc:${HOME}/.bashrc:ro"
 [ -e "${HOME}/.bash_aliases" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_aliases:${HOME}/.bash_aliases:ro"
 [ -e "${HOME}/.bash_profile" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_profile:${HOME}/.bash_profile:ro"
 


### PR DESCRIPTION
Two issues

1. When VSCode sets up a dev container it installs the ssh server in `/home/${USER}`, this folder wasn't `chown`ed previously so would fail in a permissions check.

2. `~/.bashrc` was bind-mounted `:ro`, but entrypoint.sh:103-124 appends a VENV-activation stanza to it on first interactive launch. If the stanza isn't already present, setup fails.