### PR TITLE
Enable bwrap sandbox in local dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,8 +110,10 @@ RUN if [ "$UID" != "0" ]; then \
     chown -R ${USER}:${GROUP} ${WORKDIR} /home/${USER}; \
     fi
 
-# Strip setuid/setgid bits — none are needed inside a dev container
-RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true
+# Strip setuid/setgid bits, then restore bubblewrap's setuid helper so
+# non-root users can create Codex's inner Linux sandbox inside Docker.
+RUN find / -xdev -perm /6000 -type f -exec chmod a-s {} + 2>/dev/null || true && \
+    chmod u+s /usr/bin/bwrap
 
 # Switch to user
 USER ${USER}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,33 @@ This launches an interactive shell within the container. All code in the current
 
 To use VSCode's integrated debugger with the container, we recommend using the "Dev Containers" extension. Simply `run_docker.sh` to launch the container, then press Ctrl+Shift+P (or Cmd+Shift+P on macOS) to open the command palette and select "Dev Containers: Attach to Running Container...". See [this](https://code.visualstudio.com/docs/devcontainers/attach-container) for details.
 
+### Bubblewrap sandbox support
+
+The image installs `bubblewrap` and keeps `/usr/bin/bwrap` in setuid mode so
+non-root users inside the container can create nested user/mount namespaces.
+The local launcher scripts (`run_docker.sh` and `exec_docker.sh`) also pass the
+Docker runtime options needed for Codex's Linux sandbox:
+
+```
+--cap-add=SYS_ADMIN
+--cap-add=SYS_CHROOT
+--cap-add=NET_ADMIN
+--cap-add=NET_RAW
+--cap-add=SETUID
+--cap-add=SETGID
+--cap-add=SYS_PTRACE
+--security-opt=seccomp=unconfined
+--security-opt=apparmor=unconfined
+```
+
+These options follow the [secure OpenAI Codex devcontainer profile](https://github.com/openai/codex/tree/main/.devcontainer)'s
+bwrap sandbox requirements. They are enabled by default for local launchers and
+can be disabled with:
+
+```
+DOCKER_ENABLE_BWRAP_SANDBOX=0 /path/to/docker/run_docker.sh
+```
+
 
 ### Non-interactive usage (CI)
 

--- a/exec_docker.sh
+++ b/exec_docker.sh
@@ -13,10 +13,10 @@ source "${SCRIPT_DIR}/init_docker.sh"
 docker run --rm \
            ${DOCKER_RUN_MOUNT_OPTS} \
            ${DOCKER_RUN_DEVICE_OPTS} \
+           ${DOCKER_RUN_BWRAP_OPTS} \
            -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \
-           --cap-drop=NET_RAW \
            --ulimit nofile=4096:4096 \
            compiler-dev-ubuntu-24.04:latest \
            "$@"

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -39,6 +39,28 @@ for DEV in /dev/kfd /dev/dri/*; do
   DOCKER_RUN_DEVICE_OPTS+=" --device=${DEV} --group-add=$(stat -c '%g' ${DEV})"
 done
 
-# Export for use by `run_docker.sh` and `exec_docker.sh`
+# Bubblewrap/Codex sandbox support:
+# - bwrap runs as a setuid helper in the image for non-root container users.
+# - Docker's default seccomp/AppArmor profiles can block namespace setup before
+#   bwrap/Codex install their inner sandbox, so relax them explicitly here.
+# - Mirrors https://github.com/openai/codex/blob/24be9ac0a4695274ac7921ecb692a9ffb3205fd2/.devcontainer/devcontainer.secure.json#L14
+# Set DOCKER_ENABLE_BWRAP_SANDBOX=0 to launch without these runtime options.
+DOCKER_RUN_BWRAP_OPTS="${DOCKER_RUN_BWRAP_OPTS:-}"
+DOCKER_ENABLE_BWRAP_SANDBOX="${DOCKER_ENABLE_BWRAP_SANDBOX:-1}"
+if [ "${DOCKER_ENABLE_BWRAP_SANDBOX}" = "1" ]; then
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=SYS_ADMIN"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=SYS_CHROOT"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=NET_ADMIN"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=NET_RAW"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=SETUID"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=SETGID"
+  DOCKER_RUN_BWRAP_OPTS+=" --cap-add=SYS_PTRACE"
+  DOCKER_RUN_BWRAP_OPTS+=" --security-opt=seccomp=unconfined"
+  DOCKER_RUN_BWRAP_OPTS+=" --security-opt=apparmor=unconfined"
+fi
+
+# Export for use by `run_docker.sh`, `exec_docker.sh`, and `exec_docker_ci.sh`.
+# `exec_docker_ci.sh` intentionally uses only device options from this file.
 export DOCKER_RUN_MOUNT_OPTS
 export DOCKER_RUN_DEVICE_OPTS
+export DOCKER_RUN_BWRAP_OPTS

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -13,9 +13,9 @@ source "${SCRIPT_DIR}/init_docker.sh"
 docker run -it \
            ${DOCKER_RUN_MOUNT_OPTS} \
            ${DOCKER_RUN_DEVICE_OPTS} \
+           ${DOCKER_RUN_BWRAP_OPTS} \
            -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \
-           --cap-drop=NET_RAW \
            --ulimit nofile=4096:4096 \
            compiler-dev-ubuntu-24.04:latest


### PR DESCRIPTION
## Summary

- Keep bubblewrap setuid in the local dev image so non-root users can create Codex's nested Linux sandbox.
- Mirror the secure OpenAI Codex devcontainer runtime options for local docker launchers.