### PR TITLE
Remove IREE's `third_party/benchmark` dependency.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,6 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete_${CACHE_KEY}" ]; then
         cd ${IREE_DIR}
         git submodule update --init \
             third_party/hip-build-deps \
-            third_party/benchmark \
             third_party/flatcc \
     )
 


### PR DESCRIPTION
After https://github.com/iree-org/fusilli/pull/422 fusilli will no longer require IREE to have `third_party/benchmark`.

We may want merge this and bump the docker container as part of https://github.com/iree-org/fusilli/pull/422.