### PR TITLE
Install git-lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
     curl \
     gdb \
     git \
+    git-lfs \
     gnupg \
     lcov \
     lld \
@@ -45,6 +46,7 @@ RUN apt-get update && \
     ripgrep \
     vim \
     wget && \
+    git lfs install --system && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Install git-lfs in the development image so repositories that use LFS can work inside the container without per-user setup. The image also enables Git LFS filters system-wide during build.

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)