### PR TITLE
Support host-level sibling containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     cmake-curses-gui \
     cmake \
     curl \
+    docker.io \
     gdb \
     git \
     git-lfs \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,37 @@ can be disabled with:
 DOCKER_ENABLE_BWRAP_SANDBOX=0 /path/to/docker/run_docker.sh
 ```
 
+### Host Docker access
+
+The image includes the Docker CLI. When the host has `/var/run/docker.sock`,
+`run_docker.sh` and `exec_docker.sh` mount that socket into the dev container and
+add the socket-owning group ID so the non-root container user can talk to the
+host Docker daemon. They also set `DOCKER_API_VERSION` to the host daemon's
+supported API version so the container's Docker CLI can talk to older host
+daemons. Containers launched from inside the dev container are host-level sibling
+containers, not nested containers inside the dev container.
+
+```
+docker ps
+docker run --rm hello-world
+```
+
+Disable host Docker access with:
+
+```
+DOCKER_ENABLE_HOST_DOCKER=0 /path/to/docker/run_docker.sh
+```
+
+Bind mounts passed to inner `docker run` commands are resolved by the host Docker
+daemon. Prefer mounting paths that already exist at the same absolute path on the
+host and in the dev container, for example:
+
+```
+docker run --rm -it -v "$PWD:$PWD" -w "$PWD" ubuntu:24.04 bash
+```
+
+Mounting the host Docker socket grants broad control over the host daemon, so only
+use this with trusted dev containers and workloads.
 
 ### Non-interactive usage (CI)
 

--- a/README.md
+++ b/README.md
@@ -45,23 +45,27 @@ DOCKER_ENABLE_BWRAP_SANDBOX=0 /path/to/docker/run_docker.sh
 
 ### Host Docker access
 
-The image includes the Docker CLI. When the host has `/var/run/docker.sock`,
-`run_docker.sh` and `exec_docker.sh` mount that socket into the dev container and
+The image includes the Docker CLI. Host Docker access is disabled by default
+because mounting `/var/run/docker.sock` grants broad control over the host
+daemon. When explicitly enabled on hosts that have `/var/run/docker.sock`,
+`run_docker.sh` and `exec_docker.sh` mount that socket into the dev container,
 add the socket-owning group ID so the non-root container user can talk to the
-host Docker daemon. They also set `DOCKER_API_VERSION` to the host daemon's
-supported API version so the container's Docker CLI can talk to older host
-daemons. Containers launched from inside the dev container are host-level sibling
-containers, not nested containers inside the dev container.
+host Docker daemon, and pass `DOCKER_API_VERSION` so the container Docker CLI
+can talk to older host daemons. Containers launched from inside the dev container
+are host-level sibling containers, not nested containers inside the dev
+container.
+
+Enable host Docker access with:
+
+```
+DOCKER_ENABLE_HOST_DOCKER=1 /path/to/docker/run_docker.sh
+```
+
+Once inside the dev container:
 
 ```
 docker ps
 docker run --rm hello-world
-```
-
-Disable host Docker access with:
-
-```
-DOCKER_ENABLE_HOST_DOCKER=0 /path/to/docker/run_docker.sh
 ```
 
 Bind mounts passed to inner `docker run` commands are resolved by the host Docker

--- a/exec_docker.sh
+++ b/exec_docker.sh
@@ -4,16 +4,17 @@ set -euo pipefail
 # Get the directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Build docker image if not already built
-source "${SCRIPT_DIR}/build_docker.sh"
-
 # Initialize options for docker run
 source "${SCRIPT_DIR}/init_docker.sh"
+
+# Build docker image if not already built
+source "${SCRIPT_DIR}/build_docker.sh"
 
 docker run --rm \
            ${DOCKER_RUN_MOUNT_OPTS} \
            ${DOCKER_RUN_DEVICE_OPTS} \
            ${DOCKER_RUN_BWRAP_OPTS} \
+           ${DOCKER_RUN_ENV_OPTS} \
            -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -25,15 +25,14 @@ DOCKER_RUN_MOUNT_OPTS+=" -v ${PWD}:${PWD}"
 [ -e "${HOME}/.bash_aliases" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_aliases:${HOME}/.bash_aliases:ro"
 [ -e "${HOME}/.bash_profile" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_profile:${HOME}/.bash_profile:ro"
 
-# Host Docker socket forwarding.
-# This uses the host Docker daemon from inside the dev container, so containers
-# launched from the dev container are host-level sibling containers.
-# Set DOCKER_ENABLE_HOST_DOCKER=0 to launch without host Docker access.
+# Host Docker API compatibility.
+# Export the host daemon API version before running host-side docker commands
+# from run_docker.sh and exec_docker.sh, even when socket forwarding is disabled.
 detect_host_docker_api_version() {
   local api_version
   api_version="$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || true)"
   if [ -n "${api_version}" ]; then
-    printf '%s\n' "${api_version}"
+    printf "%s\n" "${api_version}"
     return
   fi
 
@@ -42,17 +41,24 @@ detect_host_docker_api_version() {
     | tail -n 1 || true
 }
 
-DOCKER_ENABLE_HOST_DOCKER="${DOCKER_ENABLE_HOST_DOCKER:-1}"
+HOST_DOCKER_API_VERSION="${DOCKER_API_VERSION:-}"
+if [ -z "${HOST_DOCKER_API_VERSION}" ]; then
+  HOST_DOCKER_API_VERSION="$(detect_host_docker_api_version)"
+fi
+if [ -n "${HOST_DOCKER_API_VERSION}" ]; then
+  export DOCKER_API_VERSION="${HOST_DOCKER_API_VERSION}"
+fi
+
+# Host Docker socket forwarding.
+# This uses the host Docker daemon from inside the dev container, so containers
+# launched from the dev container are host-level sibling containers.
+# Set DOCKER_ENABLE_HOST_DOCKER=1 to launch with host Docker access.
+DOCKER_ENABLE_HOST_DOCKER="${DOCKER_ENABLE_HOST_DOCKER:-0}"
 if [ "${DOCKER_ENABLE_HOST_DOCKER}" = "1" ] && [ -S /var/run/docker.sock ]; then
   DOCKER_RUN_MOUNT_OPTS+=" -v /var/run/docker.sock:/var/run/docker.sock"
   DOCKER_RUN_MOUNT_OPTS+=" --group-add=$(stat -c '%g' /var/run/docker.sock)"
 
-  HOST_DOCKER_API_VERSION="${DOCKER_API_VERSION:-}"
-  if [ -z "${HOST_DOCKER_API_VERSION}" ]; then
-    HOST_DOCKER_API_VERSION="$(detect_host_docker_api_version)"
-  fi
   if [ -n "${HOST_DOCKER_API_VERSION}" ]; then
-    export DOCKER_API_VERSION="${HOST_DOCKER_API_VERSION}"
     DOCKER_RUN_ENV_OPTS+=" -e DOCKER_API_VERSION=${HOST_DOCKER_API_VERSION}"
   fi
 fi

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -4,6 +4,7 @@
 # Sensitive paths (.bash_history, .docker) are intentionally excluded.
 # Read-write mounts
 DOCKER_RUN_MOUNT_OPTS="${DOCKER_RUN_MOUNT_OPTS:-}"
+DOCKER_RUN_ENV_OPTS="${DOCKER_RUN_ENV_OPTS:-}"
 DOCKER_RUN_MOUNT_OPTS+=" -v ${PWD}:${PWD}"
 [ -e "${HOME}/.claude" ]             && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.claude:${HOME}/.claude"
 [ -e "${HOME}/.claude.json" ]        && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.claude.json:${HOME}/.claude.json"
@@ -23,6 +24,38 @@ DOCKER_RUN_MOUNT_OPTS+=" -v ${PWD}:${PWD}"
 [ -e "${HOME}/.local" ]              && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.local:${HOME}/.local:ro"
 [ -e "${HOME}/.bash_aliases" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_aliases:${HOME}/.bash_aliases:ro"
 [ -e "${HOME}/.bash_profile" ]       && DOCKER_RUN_MOUNT_OPTS+=" -v ${HOME}/.bash_profile:${HOME}/.bash_profile:ro"
+
+# Host Docker socket forwarding.
+# This uses the host Docker daemon from inside the dev container, so containers
+# launched from the dev container are host-level sibling containers.
+# Set DOCKER_ENABLE_HOST_DOCKER=0 to launch without host Docker access.
+detect_host_docker_api_version() {
+  local api_version
+  api_version="$(docker version --format '{{.Server.APIVersion}}' 2>/dev/null || true)"
+  if [ -n "${api_version}" ]; then
+    printf '%s\n' "${api_version}"
+    return
+  fi
+
+  docker version 2>&1 \
+    | sed -n 's/.*Maximum supported API version is \([0-9][0-9.]*\).*/\1/p' \
+    | tail -n 1 || true
+}
+
+DOCKER_ENABLE_HOST_DOCKER="${DOCKER_ENABLE_HOST_DOCKER:-1}"
+if [ "${DOCKER_ENABLE_HOST_DOCKER}" = "1" ] && [ -S /var/run/docker.sock ]; then
+  DOCKER_RUN_MOUNT_OPTS+=" -v /var/run/docker.sock:/var/run/docker.sock"
+  DOCKER_RUN_MOUNT_OPTS+=" --group-add=$(stat -c '%g' /var/run/docker.sock)"
+
+  HOST_DOCKER_API_VERSION="${DOCKER_API_VERSION:-}"
+  if [ -z "${HOST_DOCKER_API_VERSION}" ]; then
+    HOST_DOCKER_API_VERSION="$(detect_host_docker_api_version)"
+  fi
+  if [ -n "${HOST_DOCKER_API_VERSION}" ]; then
+    export DOCKER_API_VERSION="${HOST_DOCKER_API_VERSION}"
+    DOCKER_RUN_ENV_OPTS+=" -e DOCKER_API_VERSION=${HOST_DOCKER_API_VERSION}"
+  fi
+fi
 
 # ROCm requires accesses to the host’s /dev/kfd and /dev/dri/* device nodes, typically
 # owned by the `render` and `video` groups. The groups’ GIDs in the container must
@@ -62,5 +95,6 @@ fi
 # Export for use by `run_docker.sh`, `exec_docker.sh`, and `exec_docker_ci.sh`.
 # `exec_docker_ci.sh` intentionally uses only device options from this file.
 export DOCKER_RUN_MOUNT_OPTS
+export DOCKER_RUN_ENV_OPTS
 export DOCKER_RUN_DEVICE_OPTS
 export DOCKER_RUN_BWRAP_OPTS

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -4,16 +4,17 @@ set -euo pipefail
 # Get the directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Build docker image if not already built
-source "${SCRIPT_DIR}/build_docker.sh"
-
 # Initialize options for docker run
 source "${SCRIPT_DIR}/init_docker.sh"
+
+# Build docker image if not already built
+source "${SCRIPT_DIR}/build_docker.sh"
 
 docker run -it \
            ${DOCKER_RUN_MOUNT_OPTS} \
            ${DOCKER_RUN_DEVICE_OPTS} \
            ${DOCKER_RUN_BWRAP_OPTS} \
+           ${DOCKER_RUN_ENV_OPTS} \
            -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \


### PR DESCRIPTION
Makes host Docker socket forwarding an explicit opt-in so dev containers do not get broad host daemon access by default, while still supporting Docker CLI workflows when requested.

Adds the host daemon API version forwarding and documentation needed for older host Docker daemons and inner container bind mounts to behave predictably.

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)