### PR TITLE
Drop IREE setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_rust/m
 # Set workdir before launching container
 WORKDIR ${WORKDIR}
 
-# Install IREE, ROCm, HIP deps through an entrypoint script
+# Install ROCm/HIP deps through an entrypoint script
 # to keep the base image small and portable.
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY activate /usr/local/bin/activate

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For example:
 ```
 
 > [!NOTE]
-> To keep the docker image size small (<2GB), the installation of large libraries (e.g. ROCm/IREE) is deferred to container launch through an `entrypoint.sh`. This installation is cached locally at `${PWD}/.cache/docker` so re-runs are instantaneous. The cache is automatically invalidated when IREE or TheRock versions change. To force a clean reinstall, remove the `${PWD}/.cache/docker` directory and re-run.
+> To keep the docker image size small (<2GB), the installation of large libraries (e.g. ROCm) is deferred to container launch through an `entrypoint.sh`. This installation is cached locally at `${PWD}/.cache/docker` so re-runs are instantaneous. The cache is automatically invalidated when the TheRock version or selected distribution changes. To force a clean reinstall, remove the `${PWD}/.cache/docker` directory and re-run.
 
 Happy development!
 

--- a/activate
+++ b/activate
@@ -69,9 +69,7 @@ PATH="${VIRTUAL_ENV}/bin:${THEROCK_DIR}/bin:${PATH}"
 export PATH
 
 # save old LD_LIBRARY_PATH and re-export
-# Order loads so TheRock's IREE compiler libs do not shadow the bundled IREE libs from python wheel.
-_VENV_SITE_PACKAGES="$("${VIRTUAL_ENV}/bin/python3" -c 'import sysconfig; print(sysconfig.get_path("platlib"))')"
-_VENV_LD_LIBRARY_PATH="${_VENV_SITE_PACKAGES}/iree/compiler/_mlir_libs:${THEROCK_DIR}/lib"
+_VENV_LD_LIBRARY_PATH="${THEROCK_DIR}/lib"
 if [ -n "${LD_LIBRARY_PATH:-}" ] ; then
     _OLD_VIRTUAL_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
     LD_LIBRARY_PATH="${_VENV_LD_LIBRARY_PATH}:${LD_LIBRARY_PATH:-}"
@@ -79,7 +77,6 @@ else
     LD_LIBRARY_PATH="${_VENV_LD_LIBRARY_PATH}"
 fi
 export LD_LIBRARY_PATH
-unset _VENV_SITE_PACKAGES
 unset _VENV_LD_LIBRARY_PATH
 
 # unset PYTHONHOME if set

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,8 @@ set -euo pipefail
 DOCKER_CACHE_DIR=${PWD}/.cache/docker
 VENV_DIR=${DOCKER_CACHE_DIR}/venv
 THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
-IREE_DIR=${DOCKER_CACHE_DIR}/iree
 
 # Version pins
-IREE_GIT_TAG="${IREE_GIT_TAG:-3.12.0rc20260520}"
 THEROCK_GIT_TAG="${THEROCK_GIT_TAG:-7.14.0a20260520}"
 AMD_ARCH="${AMD_ARCH:-gfx94X}"
 
@@ -35,10 +33,10 @@ esac
 THEROCK_TAR=${THEROCK_DIST}-${THEROCK_GIT_TAG}.tar.gz
 
 # This installation is cached locally at `${PWD}/.cache/docker` so re-runs are
-# instantaneous. The cache is automatically invalidated when IREE or TheRock
-# versions change (the cache marker encodes version pins). To force a clean
-# reinstall, remove the `${PWD}/.cache/docker` dir and re-run.
-CACHE_KEY="${IREE_GIT_TAG}-${THEROCK_GIT_TAG}"
+# instantaneous. The cache is automatically invalidated when TheRock version or
+# distribution changes. To force a clean reinstall, remove the
+# `${PWD}/.cache/docker` dir and re-run.
+CACHE_KEY="${THEROCK_GIT_TAG}-${THEROCK_DIST}"
 if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete_${CACHE_KEY}" ]; then
     echo "[entrypoint.sh] Cache NOT found for '${CACHE_KEY}' at '${DOCKER_CACHE_DIR}', proceeding with installation..."
     # Remove stale cache (including old .install_complete markers and
@@ -61,24 +59,10 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete_${CACHE_KEY}" ]; then
     tar -xf ${THEROCK_DIR}/${THEROCK_TAR} -C ${THEROCK_DIR}
     rm -f ${THEROCK_DIR}/${THEROCK_TAR}
 
-    # Clone IREE source
-    echo "[entrypoint.sh] Fetching IREE from source at tag '${IREE_GIT_TAG}'..."
-    git clone --depth=1 --branch iree-${IREE_GIT_TAG} https://github.com/iree-org/iree.git ${IREE_DIR}
-    # Run this in a subshell to preserve $(pwd) for main shell
-    (
-        cd ${IREE_DIR}
-        git submodule update --init \
-            third_party/hip-build-deps \
-            third_party/flatcc \
-    )
-
     # Install python virtual env and dependencies
     echo "[entrypoint.sh] Setting up python venv and installing pip deps..."
     python3 -m venv ${VENV_DIR}
-    ${VENV_DIR}/bin/pip install \
-        lit \
-        --find-links https://iree.dev/pip-release-links.html \
-        iree-base-compiler==${IREE_GIT_TAG}
+    ${VENV_DIR}/bin/pip install lit
 
     # Make FileCheck (from system llvm-18) and clang-23, llvm-symbolizer (from TheRock) accessible in VENV
     ln -s /usr/lib/llvm-18/bin/FileCheck ${VENV_DIR}/bin/FileCheck

--- a/exec_docker.sh
+++ b/exec_docker.sh
@@ -15,7 +15,6 @@ docker run --rm \
            ${DOCKER_RUN_DEVICE_OPTS} \
            ${DOCKER_RUN_BWRAP_OPTS} \
            ${DOCKER_RUN_ENV_OPTS} \
-           -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \
            --ulimit nofile=4096:4096 \

--- a/exec_docker_ci.sh
+++ b/exec_docker_ci.sh
@@ -11,7 +11,6 @@ source "${SCRIPT_DIR}/init_docker.sh"
 docker run --rm \
            -v "${PWD}":/workspace \
            ${DOCKER_RUN_DEVICE_OPTS} \
-           -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \
            --cap-drop=NET_RAW \

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -15,7 +15,6 @@ docker run -it \
            ${DOCKER_RUN_DEVICE_OPTS} \
            ${DOCKER_RUN_BWRAP_OPTS} \
            ${DOCKER_RUN_ENV_OPTS} \
-           -e IREE_GIT_TAG=${IREE_GIT_TAG:-} \
            -e THEROCK_GIT_TAG=${THEROCK_GIT_TAG:-} \
            -e AMD_ARCH=${AMD_ARCH:-} \
            --ulimit nofile=4096:4096 \


### PR DESCRIPTION
Removes the deferred IREE compiler setup from the dev container because this image now only needs the TheRock/ROCm dependency path at startup, reducing cache churn and avoiding unnecessary source and wheel downloads.

It also keeps the activation and Docker launch environment aligned with that narrower dependency surface so cache invalidation follows TheRock version and distribution changes.

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)