### PR TITLE
Auto-detect AMD_ARCH for Docker launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ This launches an interactive shell within the container. All code in the current
 
 To use VSCode's integrated debugger with the container, we recommend using the "Dev Containers" extension. Simply `run_docker.sh` to launch the container, then press Ctrl+Shift+P (or Cmd+Shift+P on macOS) to open the command palette and select "Dev Containers: Attach to Running Container...". See [this](https://code.visualstudio.com/docs/devcontainers/attach-container) for details.
 
+### Non-interactive usage (CI)
+
+To execute commands within the container in batch mode (non-interactive):
+```
+/path/to/docker/exec_docker.sh <command>
+```
+
+For example:
+```
+/path/to/docker/exec_docker.sh echo "Hello World"
+
+/path/to/docker/exec_docker.sh bash -c "echo "Hello" && echo "World""
+```
+
 ### Bubblewrap sandbox support
 
 The image installs `bubblewrap` and keeps `/usr/bin/bwrap` in setuid mode so
@@ -79,19 +93,21 @@ docker run --rm -it -v "$PWD:$PWD" -w "$PWD" ubuntu:24.04 bash
 Mounting the host Docker socket grants broad control over the host daemon, so only
 use this with trusted dev containers and workloads.
 
-### Non-interactive usage (CI)
+### GPU architecture selection
 
-To execute commands within the container in batch mode (non-interactive):
+The launch scripts pass `AMD_ARCH` into the container so `entrypoint.sh` can
+download the matching TheRock distribution. If `AMD_ARCH` is unset, the scripts
+try to detect the first host GPU reported by `rocminfo`.
+
+Override detection when needed:
+
 ```
-/path/to/docker/exec_docker.sh <command>
+AMD_ARCH=gfx950 /path/to/docker/run_docker.sh
 ```
 
-For example:
-```
-/path/to/docker/exec_docker.sh echo "Hello World"
-
-/path/to/docker/exec_docker.sh bash -c "echo "Hello" && echo "World""
-```
+Supported values are `gfx94X`/`gfx942`, `gfx950`, `gfx110X`/`gfx1100`-`gfx1103`,
+and `gfx120X`/`gfx1200`/`gfx1201`. If no ROCm GPU is detected and
+`AMD_ARCH` is not set, the container falls back to `gfx94X`.
 
 > [!NOTE]
 > To keep the docker image size small (<2GB), the installation of large libraries (e.g. ROCm) is deferred to container launch through an `entrypoint.sh`. This installation is cached locally at `${PWD}/.cache/docker` so re-runs are instantaneous. The cache is automatically invalidated when the TheRock version or selected distribution changes. To force a clean reinstall, remove the `${PWD}/.cache/docker` directory and re-run.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,17 +11,17 @@ THEROCK_DIR=${DOCKER_CACHE_DIR}/therock
 THEROCK_GIT_TAG="${THEROCK_GIT_TAG:-7.14.0a20260529}"
 AMD_ARCH="${AMD_ARCH:-gfx94X}"
 
-case "$AMD_ARCH" in
-  gfx94X | gfx942)
+case "${AMD_ARCH,,}" in
+  gfx94x | gfx942)
     THEROCK_DIST="therock-dist-linux-gfx94X-dcgpu"
     ;;
   gfx950)
     THEROCK_DIST="therock-dist-linux-gfx950-dcgpu"
     ;;
-  gfx110X | gfx1100)
+  gfx110x | gfx1100 | gfx1101 | gfx1102 | gfx1103)
     THEROCK_DIST="therock-dist-linux-gfx110X-all"
     ;;
-  gfx120X | gfx1201)
+  gfx120x | gfx1200 | gfx1201)
     THEROCK_DIST="therock-dist-linux-gfx120X-all"
     ;;
   *)
@@ -44,7 +44,7 @@ if [ ! -f "${DOCKER_CACHE_DIR}/.install_complete_${CACHE_KEY}" ]; then
     rm -rf "${DOCKER_CACHE_DIR}"
     mkdir -p "${DOCKER_CACHE_DIR}"
 
-    # Install TheRock (ROCm/HIP) for GFX942
+    # Install TheRock (ROCm/HIP) for the selected GPU family.
     echo "[entrypoint.sh] Downloading TheRock (ROCm/HIP) prebuilt distribution '${THEROCK_DIST}' at tag '${THEROCK_GIT_TAG}'..."
     mkdir -p ${THEROCK_DIR}
     THEROCK_CDN_URL="https://rocm.nightlies.amd.com/tarball/${THEROCK_TAR}"

--- a/init_docker.sh
+++ b/init_docker.sh
@@ -63,6 +63,38 @@ if [ "${DOCKER_ENABLE_HOST_DOCKER}" = "1" ] && [ -S /var/run/docker.sock ]; then
   fi
 fi
 
+# AMD GPU architecture selection.
+# If the user does not set AMD_ARCH explicitly, detect the first host GPU
+# reported by ROCm and map it to the matching TheRock distribution family.
+detect_host_amd_arch() {
+  local arch
+  arch=""
+
+  if command -v rocminfo >/dev/null 2>&1; then
+    arch="$(awk '/^[[:space:]]*Name:[[:space:]]*gfx/ { print $2; exit }' < <(rocminfo 2>/dev/null) || true)"
+  fi
+
+  case "${arch}" in
+    gfx94[0-9])
+      printf "%s\n" "gfx94X"
+      ;;
+    gfx950)
+      printf "%s\n" "gfx950"
+      ;;
+    gfx110[0-9])
+      printf "%s\n" "gfx110X"
+      ;;
+    gfx120[0-9])
+      printf "%s\n" "gfx120X"
+      ;;
+  esac
+}
+
+if [ -z "${AMD_ARCH:-}" ]; then
+  AMD_ARCH="$(detect_host_amd_arch)"
+fi
+export AMD_ARCH
+
 # ROCm requires accesses to the host’s /dev/kfd and /dev/dri/* device nodes, typically
 # owned by the `render` and `video` groups. The groups’ GIDs in the container must
 # match the host’s to access the resources. Sometimes the device nodes may be owned by


### PR DESCRIPTION
Detects the host ROCm GPU family when AMD_ARCH is not set so MI350X hosts select the GFX950 TheRock distribution automatically, while preserving explicit AMD_ARCH overrides.

The entrypoint now accepts architecture aliases case-insensitively, and the README documents the selection flow with the launcher usage sections in a more natural order.

Co-authored-by: GPT 5.5 <codex@openai.com>

🤖 Generated with [Codex](https://openai.com/codex)